### PR TITLE
Use new namespace for Flow within composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "role": "Developer"
     }],
     "require": {
-        "typo3/flow": "*",
+        "neos/flow": "*",
         "opauth/opauth": "@dev"
     },
     "autoload": {


### PR DESCRIPTION
See this warning you get from composer while using your package:
Package typo3/flow is abandoned, you should avoid using it. Use neos/flow instead.